### PR TITLE
绿化pdf元数据

### DIFF
--- a/openstd_spider/cli.py
+++ b/openstd_spider/cli.py
@@ -2,7 +2,7 @@ import sys
 from enum import Enum
 from pathlib import Path
 from tempfile import TemporaryDirectory
-
+from pypdf import PdfReader, PdfWriter
 from rich.box import SQUARE
 from rich.console import Console
 from rich.panel import Panel
@@ -243,6 +243,14 @@ def download_file(std_id: str, download_path: Path):
             ),
         )
         progress.remove_task(bar)
+        
+    reader = PdfReader(download_path)
+    writer = PdfWriter()
+    for page in reader.pages:
+        writer.add_page(page)
+    writer.metadata = None
+    with download_path.open("wb") as output_pdf:
+        writer.write(output_pdf)
 
 
 class StdStatusSelect(Enum):


### PR DESCRIPTION
以直接下载方式得到的pdf，含有多余的元数据，在浏览器中打开后，没有权限做标注，对此进行了绿化